### PR TITLE
Fix vert x instance server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation project (':EE-Visualization')
   }else {
     implementation 'com.github.Apollo-Core:EE-Core:v1.0.0'
-    implementation 'com.github.Apollo-Core:EE-Guice:v1.0.0'
+    implementation 'com.github.Apollo-Core:EE-Guice:fixSingleVertXinstance-SNAPSHOT'
     implementation 'com.github.Apollo-Core:EE-Model:v1.0.0'
     implementation 'com.github.Apollo-Core:EE-IO:v1.0.0'
     implementation 'com.github.Apollo-Core:EE-Enactables:v1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -37,11 +37,11 @@ dependencies {
     implementation project (':EE-Visualization')
   }else {
     implementation 'com.github.Apollo-Core:EE-Core:v1.0.0'
-    implementation 'com.github.Apollo-Core:EE-Guice:fixSingleVertXinstance-SNAPSHOT'
+    implementation 'com.github.Apollo-Core:EE-Guice:2b83053cd2'
     implementation 'com.github.Apollo-Core:EE-Model:v1.0.0'
-    implementation 'com.github.Apollo-Core:EE-IO:v1.0.0'
-    implementation 'com.github.Apollo-Core:EE-Enactables:v1.0.0'
-    implementation 'com.github.Apollo-Core:EE-Control:v1.0.0'
+    implementation 'com.github.Apollo-Core:EE-IO:main-SNAPSHOT'
+    implementation 'com.github.Apollo-Core:EE-Enactables:master-SNAPSHOT'
+    implementation 'com.github.Apollo-Core:EE-Control:master-SNAPSHOT'
     implementation 'com.github.Apollo-Core:EE-Visualization:v1.0.0'
     implementation 'com.github.Apollo-Core:SC-Core:v1.0.0'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -37,13 +37,13 @@ dependencies {
     implementation project (':EE-Visualization')
   }else {
     implementation 'com.github.Apollo-Core:EE-Core:v1.0.0'
-    implementation 'com.github.Apollo-Core:EE-Guice:2b83053cd2'
+    implementation 'com.github.Apollo-Core:EE-Guice:v1.0.1'
     implementation 'com.github.Apollo-Core:EE-Model:v1.0.0'
-    implementation 'com.github.Apollo-Core:EE-IO:main-SNAPSHOT'
-    implementation 'com.github.Apollo-Core:EE-Enactables:master-SNAPSHOT'
-    implementation 'com.github.Apollo-Core:EE-Control:master-SNAPSHOT'
-    implementation 'com.github.Apollo-Core:EE-Visualization:v1.0.0'
-    implementation 'com.github.Apollo-Core:SC-Core:v1.0.0'
+    implementation 'com.github.Apollo-Core:EE-IO:v1.0.1'
+    implementation 'com.github.Apollo-Core:EE-Enactables:v1.0.1'
+    implementation 'com.github.Apollo-Core:EE-Control:v1.0.1'
+    implementation 'com.github.Apollo-Core:EE-Visualization:v1.0.1'
+    implementation 'com.github.Apollo-Core:SC-Core:v1.0.1'
   }
 
   // dependency to Opt4J

--- a/src/main/java/at/uibk/dps/ee/deploy/run/ImplementationRunBare.java
+++ b/src/main/java/at/uibk/dps/ee/deploy/run/ImplementationRunBare.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import at.uibk.dps.ee.deploy.FileStringConverter;
 import at.uibk.dps.ee.guice.EeCoreInjectable;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 
 /**
  * The {@link ImplementationRunBare} runs an implementation as a method.
@@ -12,6 +13,15 @@ import io.vertx.core.Future;
  *
  */
 public class ImplementationRunBare extends ImplementationRunAbstract {
+
+  /**
+   * Standard constructor.
+   * 
+   * @param vertx the VertX instance used by the triggerring server
+   */
+  public ImplementationRunBare(Vertx vertx) {
+    super(vertx);
+  }
 
   /**
    * Implements the application as specified by the provided strings. Returns the

--- a/src/main/java/at/uibk/dps/ee/deploy/run/ImplementationRunConfigured.java
+++ b/src/main/java/at/uibk/dps/ee/deploy/run/ImplementationRunConfigured.java
@@ -6,6 +6,7 @@ import at.uibk.dps.ee.deploy.spec.SpecFromString;
 import at.uibk.dps.ee.guice.EeCoreInjectable;
 import at.uibk.dps.sc.core.ScheduleModel;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 
 /**
  * The {@link ImplementationRunConfigured} is used to implement an application
@@ -18,6 +19,15 @@ import io.vertx.core.Future;
 public class ImplementationRunConfigured extends ImplementationRunAbstract {
 
   protected Optional<EeCoreInjectable> eeCore = Optional.empty();
+
+  /**
+   * The standard constructor
+   * 
+   * @param vertx the VertX instance used by the server triggerring the execution
+   */
+  public ImplementationRunConfigured(Vertx vertx) {
+    super(vertx);
+  }
 
   /**
    * Configures the eeCore to be used for the implementation.

--- a/src/main/java/at/uibk/dps/ee/deploy/run/VertxProviderModule.java
+++ b/src/main/java/at/uibk/dps/ee/deploy/run/VertxProviderModule.java
@@ -1,0 +1,32 @@
+package at.uibk.dps.ee.deploy.run;
+
+import org.opt4j.core.start.Opt4JModule;
+import at.uibk.dps.ee.guice.starter.VertxProvider;
+import io.vertx.core.Vertx;
+
+/**
+ * The VertX provider module is used to bind the {@link VertxProvider} to an
+ * instance which is created with a provided VertX context, instead of letting
+ * Guice create a new VertX instance when providing the VertXProvider singleton.
+ * 
+ * @author Fedor Smirnov
+ */
+public class VertxProviderModule extends Opt4JModule {
+
+  protected final Vertx vertxInstance;
+
+  /**
+   * The constructor to be used (this module has to be instantiated manually).
+   * 
+   * @param vertxInstance the VertX instance which is to be used.
+   */
+  public VertxProviderModule(Vertx vertxInstance) {
+    this.vertxInstance = vertxInstance;
+  }
+
+  @Override
+  protected void config() {
+    VertxProvider providerWithFixInstance = new VertxProvider(vertxInstance);
+    bind(VertxProvider.class).toInstance(providerWithFixInstance);
+  }
+}

--- a/src/main/java/at/uibk/dps/ee/deploy/server/ApolloServer.java
+++ b/src/main/java/at/uibk/dps/ee/deploy/server/ApolloServer.java
@@ -41,9 +41,9 @@ public class ApolloServer {
   public ApolloServer(final Vertx vertx, final String host) {
     this.router = Router.router(vertx);
     this.server = vertx.createHttpServer();
-    this.configuredRun = new ImplementationRunConfigured();
+    this.configuredRun = new ImplementationRunConfigured(vertx);
     this.host = Optional.of(host);
-    configureRoutes();
+    configureRoutes(vertx);
   }
 
   /**
@@ -54,8 +54,8 @@ public class ApolloServer {
   public ApolloServer(final Vertx vertx) {
     this.router = Router.router(vertx);
     this.server = vertx.createHttpServer();
-    this.configuredRun = new ImplementationRunConfigured();
-    configureRoutes();
+    this.configuredRun = new ImplementationRunConfigured(vertx);
+    configureRoutes(vertx);
   }
 
   /**
@@ -88,8 +88,10 @@ public class ApolloServer {
 
   /**
    * Configures the routes of the server.
+   * 
+   * @param vertx the vertx instance used by the server
    */
-  protected final void configureRoutes() {
+  protected final void configureRoutes(Vertx vertx) {
     // help message route
     final Route routeHelp = router.route(ConstantsServer.routeHelpRoutes).method(HttpMethod.GET);
     final RequestHandlerRoutes handlerHelp = new RequestHandlerRoutes();
@@ -102,7 +104,7 @@ public class ApolloServer {
     bareRoute.blockingHandler(handlerBareStrings::handle);
 
     // routes for the configured enactment
-    final ImplementationRunConfigured configuredRun = new ImplementationRunConfigured();
+    final ImplementationRunConfigured configuredRun = new ImplementationRunConfigured(vertx);
 
     // config route
     final Route configRoute = router.route(ConstantsServer.routeConfigStrings)

--- a/src/main/java/at/uibk/dps/ee/deploy/server/routes/RequestHandlerBareStrings.java
+++ b/src/main/java/at/uibk/dps/ee/deploy/server/routes/RequestHandlerBareStrings.java
@@ -22,7 +22,7 @@ public class RequestHandlerBareStrings implements Handler<RoutingContext> {
     final String inputString = json.getString(ConstantsServer.jsonKeyInput);
     final String specString = json.getString(ConstantsServer.jsonKeySpec);
     final String configString = json.getString(ConstantsServer.jsonKeyConfigs);
-    final ImplementationRunBare implRun = new ImplementationRunBare();
+    final ImplementationRunBare implRun = new ImplementationRunBare(ctx.vertx());
     final String apolloResponse =
         implRun.implement(inputString, specString, configString).toString();
     response.end(apolloResponse);

--- a/src/test/java/at/uibk/dps/ee/deploy/run/ImplementationRunAbstractTest.java
+++ b/src/test/java/at/uibk/dps/ee/deploy/run/ImplementationRunAbstractTest.java
@@ -2,20 +2,28 @@ package at.uibk.dps.ee.deploy.run;
 
 import static org.junit.jupiter.api.Assertions.*;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import com.google.gson.JsonObject;
 import com.google.inject.Module;
 import at.uibk.dps.ee.deploy.resources.ReadTestStrings;
+import io.vertx.core.Vertx;
 import net.sf.opendse.model.Specification;
 
 public class ImplementationRunAbstractTest {
 
   protected class ImplementationRunMock extends ImplementationRunAbstract {
+    public ImplementationRunMock(Vertx vertx) {
+      super(vertx);
+    }
   }
+
+  protected Vertx vertx;
 
   @Test
   public void testReadConfig() {
-    ImplementationRunMock tested = new ImplementationRunMock();
+    ImplementationRunMock tested = new ImplementationRunMock(vertx);
     String testString = ReadTestStrings.configString;
     Set<Module> result = tested.readModuleList(testString);
     assertEquals(3, result.size());
@@ -23,7 +31,7 @@ public class ImplementationRunAbstractTest {
 
   @Test
   public void testReadInput() {
-    ImplementationRunAbstract tested = new ImplementationRunMock();
+    ImplementationRunAbstract tested = new ImplementationRunMock(vertx);
     String testString = ReadTestStrings.inputString;
     JsonObject result = tested.readInputString(testString);
     assertEquals(3, result.get("input1").getAsInt());
@@ -31,7 +39,7 @@ public class ImplementationRunAbstractTest {
 
   @Test
   public void testReadSpec() {
-    ImplementationRunAbstract tested = new ImplementationRunMock();
+    ImplementationRunAbstract tested = new ImplementationRunMock(vertx);
     String testString = ReadTestStrings.specString;
     Specification result = tested.readSpecification(testString);
     assertEquals(1, result.getArchitecture().getVertexCount());
@@ -39,4 +47,13 @@ public class ImplementationRunAbstractTest {
     assertEquals(5, result.getMappings().size());
   }
 
+  @BeforeEach
+  void setup() {
+    vertx = Vertx.vertx();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    vertx.close();
+  }
 }

--- a/src/test/java/at/uibk/dps/ee/deploy/run/ImplementationRunBareTest.java
+++ b/src/test/java/at/uibk/dps/ee/deploy/run/ImplementationRunBareTest.java
@@ -2,22 +2,37 @@ package at.uibk.dps.ee.deploy.run;
 
 import static org.junit.jupiter.api.Assertions.*;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import com.google.gson.JsonObject;
 import at.uibk.dps.ee.deploy.resources.ReadTestStrings;
+import io.vertx.core.Vertx;
 
 public class ImplementationRunBareTest {
 
+  protected Vertx vertx;
+  
   @Test
   @Timeout(value = 10, unit = TimeUnit.SECONDS)
   public void testRun() {
-    ImplementationRunBare tested = new ImplementationRunBare();
+    ImplementationRunBare tested = new ImplementationRunBare(vertx);
     String configString = ReadTestStrings.configString;
     String specString = ReadTestStrings.specString;
     String inputString = ReadTestStrings.inputString;
     JsonObject result = tested.implement(inputString, specString, configString);
     assertTrue(result.has("result"));
     assertEquals(16, result.get("result").getAsInt());
+  }
+  
+  @BeforeEach
+  void setup() {
+    this.vertx = Vertx.vertx();
+  }
+  
+  @AfterEach
+  void cleanUp() {
+    vertx.close();
   }
 }

--- a/src/test/java/at/uibk/dps/ee/deploy/run/ImplementationRunConfiguredTest.java
+++ b/src/test/java/at/uibk/dps/ee/deploy/run/ImplementationRunConfiguredTest.java
@@ -2,17 +2,22 @@ package at.uibk.dps.ee.deploy.run;
 
 import static org.junit.jupiter.api.Assertions.*;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import com.google.gson.JsonObject;
 import at.uibk.dps.ee.deploy.resources.ReadTestStrings;
+import io.vertx.core.Vertx;
 
 public class ImplementationRunConfiguredTest {
+
+  protected Vertx vertx;
 
   @Test
   @Timeout(value = 5, unit = TimeUnit.SECONDS)
   public void testRun() {
-    ImplementationRunConfigured tested = new ImplementationRunConfigured();
+    ImplementationRunConfigured tested = new ImplementationRunConfigured(vertx);
     String configString = ReadTestStrings.configString;
     String specString = ReadTestStrings.specString;
     String inputString = ReadTestStrings.inputString;
@@ -26,9 +31,19 @@ public class ImplementationRunConfiguredTest {
   @Test
   public void testNoConfig() {
     assertThrows(IllegalStateException.class, () -> {
-      ImplementationRunConfigured tested = new ImplementationRunConfigured();
+      ImplementationRunConfigured tested = new ImplementationRunConfigured(vertx);
       String inputString = ReadTestStrings.inputString;
       tested.implementInput(inputString);
     });
+  }
+
+  @BeforeEach
+  void setup() {
+    this.vertx = Vertx.vertx();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    vertx.close();
   }
 }


### PR DESCRIPTION
Fix to make sure that the server used to handle application orchestration requests operates on the same VertX instance as the underlying Apollo instance.